### PR TITLE
fix: use Debian Node image so arm64 Docker builds succeed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:22-alpine@sha256:c610fcdfb1d5b4740dd70c284ed3cb16bb857e0f7166196e36a5501df7a3aa32
+FROM node:22-bookworm-slim@sha256:d649c27dae7ba0137b3cef5dd75baa422c08dc3d9e3fc0c23dfb172dc3cc6436
 
-RUN addgroup -g 1001 -S appuser && \
-    adduser -S appuser -u 1001 -G appuser && \
+RUN groupadd --system --gid 1001 appuser && \
+    useradd --system --uid 1001 --gid appuser --home /nonexistent --shell /usr/sbin/nologin appuser && \
     mkdir -p /data && \
     chown appuser:appuser /data
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "jw-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "MCP server for JW.org content: Bible scripture lookup with study content, workbook materials, Watchtower articles, and video captions",
   "author": {
     "name": "advenimus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jw-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jw-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jw-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "MCP server for JW.org content: Bible scripture lookup with study content, workbook materials, Watchtower articles, and video captions",
   "main": "src/index.js",
   "type": "module",


### PR DESCRIPTION
## Summary

v1.3.0 npm publish succeeded. The GHCR job failed: QEMU illegal instruction during `npm ci` on `linux/arm64` with `node:22-alpine`.

Switch the image to `node:22-bookworm-slim` so amd64 and arm64 both build. Bump to 1.3.1 so we can tag a new release.

## Test plan

- [ ] Release workflow docker job is green
- [ ] `docker pull ghcr.io/advenimus/jw-mcp:v1.3.1` works