### PR TITLE
fix: allow OAuth login redirect to remote MCP clients

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "jw-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "MCP server for JW.org content: Bible scripture lookup with study content, workbook materials, Watchtower articles, and video captions",
   "author": {
     "name": "advenimus",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jw-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jw-mcp",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jw-mcp",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "MCP server for JW.org content: Bible scripture lookup with study content, workbook materials, Watchtower articles, and video captions",
   "main": "src/index.js",
   "type": "module",

--- a/src/auth/csp.js
+++ b/src/auth/csp.js
@@ -1,0 +1,35 @@
+// Browsers apply form-action to the 302 after a login POST, so 'self' alone blocks Grok/Claude/ChatGPT callbacks.
+const CSP_START = "default-src 'none'; style-src 'unsafe-inline'; form-action ";
+const CSP_END = "; frame-ancestors 'none'; base-uri 'none'";
+
+export const DEFAULT_CONTENT_SECURITY_POLICY = `${CSP_START}'self'${CSP_END}`;
+
+function formActionOrigin(redirectUri) {
+  if (!redirectUri) {
+    return null;
+  }
+
+  let url;
+  try {
+    url = new URL(String(redirectUri));
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return null;
+  }
+
+  const origin = url.origin;
+  if (!origin || origin === 'null' || /[\s;,'"]/.test(origin)) {
+    return null;
+  }
+
+  return origin;
+}
+
+export function contentSecurityPolicy(redirectUri) {
+  const origin = formActionOrigin(redirectUri);
+  const formAction = origin ? `'self' ${origin}` : "'self'";
+  return `${CSP_START}${formAction}${CSP_END}`;
+}

--- a/src/auth/provider.js
+++ b/src/auth/provider.js
@@ -13,6 +13,7 @@ import {
   REFRESH_TOKEN_LIFETIME_MS,
 } from './constants.js';
 import { fetchClientIdMetadata, isHttpsClientId } from './cimd.js';
+import { contentSecurityPolicy } from './csp.js';
 import { renderDeniedPage, renderLoginPage } from './login-page.js';
 import { safeCompare } from './safe-compare.js';
 import { createAuthState, InMemoryClientsStore, TokenStore } from './store.js';
@@ -135,6 +136,7 @@ export class McpOAuthProvider {
     }
 
     res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Content-Security-Policy', contentSecurityPolicy(params.redirectUri));
     res.send(renderLoginPage({
       pendingId,
       clientName: client.client_name || client.client_id,
@@ -170,6 +172,7 @@ export class McpOAuthProvider {
       redirectUrl.searchParams.set('state', pending.params.state);
     }
 
+    res.setHeader('Content-Security-Policy', contentSecurityPolicy(pending.params.redirectUri));
     res.redirect(redirectUrl.toString());
   }
 

--- a/src/http-server.js
+++ b/src/http-server.js
@@ -16,6 +16,7 @@ import {
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { McpOAuthProvider, MCP_SCOPE, RESOURCE_NAME } from './auth.js';
+import { DEFAULT_CONTENT_SECURITY_POLICY } from './auth/csp.js';
 import { mcpResourceUrl, originUrl as toOriginUrl } from './auth/urls.js';
 import { createMcpServer } from './mcp-server.js';
 
@@ -26,8 +27,7 @@ const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
 const AUTHORIZE_RATE_MAX = 100;
 const CALLBACK_RATE_MAX = 20;
 const SWEEP_INTERVAL_MAX_MS = 60 * 1000;
-const CONTENT_SECURITY_POLICY =
-  "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'";
+const CONTENT_SECURITY_POLICY = DEFAULT_CONTENT_SECURITY_POLICY;
 
 function isLoopbackHostname(hostname) {
   const host = String(hostname || '').replace(/^\[|\]$/g, '').toLowerCase();

--- a/tests/auth/csp.test.js
+++ b/tests/auth/csp.test.js
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_CONTENT_SECURITY_POLICY,
+  contentSecurityPolicy,
+} from '../../src/auth/csp.js';
+
+describe('contentSecurityPolicy', () => {
+  it('defaults to form-action self', () => {
+    assert.equal(
+      DEFAULT_CONTENT_SECURITY_POLICY,
+      "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'"
+    );
+    assert.equal(contentSecurityPolicy(), DEFAULT_CONTENT_SECURITY_POLICY);
+  });
+
+  it('adds the OAuth redirect origin so browsers can follow the post-login 302', () => {
+    assert.equal(
+      contentSecurityPolicy('https://grok.com/auth/callback'),
+      "default-src 'none'; style-src 'unsafe-inline'; form-action 'self' https://grok.com; frame-ancestors 'none'; base-uri 'none'"
+    );
+  });
+
+  it('ignores unsafe or unusable redirect URIs', () => {
+    assert.equal(contentSecurityPolicy('javascript:alert(1)'), DEFAULT_CONTENT_SECURITY_POLICY);
+    assert.equal(contentSecurityPolicy('not a url'), DEFAULT_CONTENT_SECURITY_POLICY);
+    assert.equal(contentSecurityPolicy('data:text/html,hi'), DEFAULT_CONTENT_SECURITY_POLICY);
+  });
+});

--- a/tests/auth/provider.test.js
+++ b/tests/auth/provider.test.js
@@ -78,6 +78,24 @@ describe('McpOAuthProvider', () => {
     assert.equal(redirect.searchParams.get('state'), 'state-123');
   });
 
+  it('lets the browser follow the OAuth redirect after login', async () => {
+    const provider = createProvider();
+    const login = mockRes();
+    await provider.authorize(testClient(), authParams(), login);
+    assert.match(
+      login.headers['Content-Security-Policy'],
+      /form-action 'self' http:\/\/localhost:9999(?:;|$)/
+    );
+
+    const callback = mockRes();
+    await provider.handleAuthCallback(pendingIdFromLoginHtml(login.body), SECRET, callback);
+    assert.equal(callback.statusCode, 302);
+    assert.match(
+      callback.headers['Content-Security-Policy'],
+      /form-action 'self' http:\/\/localhost:9999(?:;|$)/
+    );
+  });
+
   it('rejects pending auths older than 10 minutes on callback', async () => {
     let now = Date.now();
     const provider = createProvider({ now: () => now });

--- a/tests/http-oauth.test.js
+++ b/tests/http-oauth.test.js
@@ -3,10 +3,10 @@ import http from 'node:http';
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHttpApp } from '../src/http-server.js';
+import { DEFAULT_CONTENT_SECURITY_POLICY as CSP } from '../src/auth/csp.js';
 import { completeOAuthHandshake, mcpRpc } from './handshake.js';
 
 const SECRET = 'test-secret-value';
-const CSP = "default-src 'none'; style-src 'unsafe-inline'; form-action 'self'; frame-ancestors 'none'; base-uri 'none'";
 
 function getFreePort() {
   return new Promise((resolve, reject) => {
@@ -142,6 +142,37 @@ describe('HTTP OAuth MCP server', () => {
     const response = await fetch(`${origin}/authorize`);
     assertSecurityHeaders(response.headers);
     assert.equal(response.headers.get('x-frame-options'), 'DENY');
+  });
+
+  it('allows the client redirect origin in login page CSP', async () => {
+    const redirectUri = `${origin}/oauth/callback`;
+    const registerResponse = await fetch(`${origin}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        client_name: 'csp-test',
+        redirect_uris: [redirectUri],
+        token_endpoint_auth_method: 'none',
+        grant_types: ['authorization_code', 'refresh_token'],
+        response_types: ['code'],
+      }),
+    });
+    assert.equal(registerResponse.ok, true);
+    const client = await registerResponse.json();
+
+    const authorizeUrl = new URL('/authorize', origin);
+    authorizeUrl.searchParams.set('response_type', 'code');
+    authorizeUrl.searchParams.set('client_id', client.client_id);
+    authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+    authorizeUrl.searchParams.set('code_challenge', 'A'.repeat(43));
+    authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+    authorizeUrl.searchParams.set('resource', mcpUrl);
+
+    const loginResponse = await fetch(authorizeUrl);
+    assert.equal(loginResponse.status, 200);
+    const csp = loginResponse.headers.get('content-security-policy') || '';
+    assert.match(csp, /default-src 'none'/);
+    assert.match(csp, new RegExp(`form-action 'self' ${origin.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?:;|$)`));
   });
 
   it('rate-limits /authorize before CIMD lookup', async () => {


### PR DESCRIPTION
## Summary
Browsers apply CSP `form-action` to the redirect after the login form POST. `form-action 'self'` blocked Grok, Claude, and ChatGPT callbacks.

The first Authorize click looked like it did nothing. The second click showed `Authorization request expired.`

This lets the login page allow only that client's own HTTPS origin. No hardcoded list of AI sites.

Version bump to 1.3.2.

## Test plan
- [x] `npm test` (63 pass)
- [x] `npm run test:coverage` (overall 86%+)
- [x] Live Grok connector login succeeded after the server overlay
- [ ] After merge and tag `v1.3.2`, confirm npm `jw-mcp@1.3.2` and `ghcr.io/advenimus/jw-mcp:v1.3.2`